### PR TITLE
added test_ravel_array_like_transformation()

### DIFF
--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -975,6 +975,18 @@ def test_ravel():
 
     assert_eq(x.flatten(), a.flatten())
     assert_eq(np.ravel(x), da.ravel(a))
+    
+
+def test_ravel_array_like_transformation():
+
+    # int
+    assert_eq(np.ravel(0), da.ravel(0))
+    # list
+    assert_eq(np.ravel([0, 0]), da.ravel([0, 0]))
+    # tuple
+    assert_eq(np.ravel((0, 0)), da.ravel((0, 0)))
+    # nested -> tuples in list
+    assert_eq(np.ravel([(0,), (0,)]), da.ravel([(0,), (0,)]))
 
 
 def test_ravel_1D_no_op():


### PR DESCRIPTION
test to see if array_like arguments are accepted

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
